### PR TITLE
Display supervisor photos in sorted grids

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Welcome to the Supervisor Portfolio repository!
 This project collects supervisor profiles and automatically generates:
 - 🌐 A public website showcasing each supervisor
 - 📄 A downloadable master PDF portfolio
+- 🖼️ An index page that displays supervisor photos in a responsive, topic‑grouped grid
 
 The website and PDF are continuously updated and hosted via **GitHub Pages**.
 

--- a/src/build.py
+++ b/src/build.py
@@ -45,6 +45,9 @@ for supervisor in supervisors:
 
 print(f"✅ Loaded {len(supervisors)} supervisors.")
 
+# Ensure deterministic ordering: first by unit, then by name
+supervisors.sort(key=lambda s: (s.get("unit", ""), s["name"]))
+
 # ---------- Generate supervisor pages ----------
 os.makedirs(os.path.join(PUBLIC_FOLDER, "supervisors"), exist_ok=True)
 

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -56,23 +56,33 @@
       text-decoration: underline;
     }
 
-    ul {
-      padding-left: 20px;
+    .supervisor-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+      gap: 20px;
       margin-top: 10px;
+      justify-items: center;
     }
 
-    li {
-      margin-bottom: 8px;
-      font-size: 16px;
-    }
-
-    li a {
+    .supervisor-card {
+      text-align: center;
       text-decoration: none;
       color: #0077cc;
+      font-size: 14px;
     }
 
-    li a:hover {
-      text-decoration: underline;
+    .supervisor-card img {
+      width: 150px;
+      height: 150px;
+      object-fit: cover;
+      border-radius: 8px;
+      border: 2px solid #ccc;
+      background-color: #f9f9f9;
+    }
+
+    .supervisor-card span {
+      display: block;
+      margin-top: 8px;
     }
 
     .back-button {
@@ -102,10 +112,6 @@
       h2 {
         font-size: 24px;
       }
-
-      li {
-        font-size: 18px;
-      }
     }
   </style>
 </head>
@@ -123,17 +129,16 @@
       {% set _ = subjects.setdefault(supervisor.unit, []).append(supervisor) %}
     {% endfor %}
 
-    {% for subject, supervisors_in_subject in subjects.items() %}
+    {% for subject, supervisors_in_subject in subjects | dictsort %}
       <h2>{{ subject }}</h2>
-      <ul>
-        {% for supervisor in supervisors_in_subject %}
-          <li>
-            <a href="./supervisors/{{ supervisor.slug }}.html">
-              {{ supervisor.name }}
-            </a> — {{ supervisor.group }}
-          </li>
+      <div class="supervisor-grid">
+        {% for supervisor in supervisors_in_subject | sort(attribute='name') %}
+          <a href="./supervisors/{{ supervisor.slug }}.html" class="supervisor-card">
+            <img src="{{ supervisor.photo_url }}" alt="{{ supervisor.name }}">
+            <span>{{ supervisor.name }}</span>
+          </a>
         {% endfor %}
-      </ul>
+      </div>
     {% endfor %}
 
     <div class="back-button">

--- a/src/templates/pdf.html
+++ b/src/templates/pdf.html
@@ -30,21 +30,30 @@
       border-bottom: 1px solid #ccc;
       padding-bottom: 3px;
     }
-    .unit-section ul {
-      list-style: none;
-      padding-left: 0;
-      margin-top: 0;
+    .unit-grid {
+      display: grid;
+      grid-template-columns: repeat(6, 1fr);
+      gap: 10px;
+      justify-items: center;
+      margin-top: 10px;
     }
-    .unit-section li {
-      margin-bottom: 2px;
-      font-size: 13px;
-    }
-    .unit-section a {
-      color: #0077cc;
+    .unit-grid a {
       text-decoration: none;
+      color: #0077cc;
+      font-size: 11px;
+      text-align: center;
     }
-    .unit-section a:hover {
-      text-decoration: underline;
+    .unit-grid img {
+      width: 90px;
+      height: 90px;
+      object-fit: cover;
+      border-radius: 4px;
+      border: 1px solid #ccc;
+      background: #f4f4f4;
+    }
+    .unit-grid span {
+      display: block;
+      margin-top: 4px;
     }
     .supervisor {
       margin-top: 20px;
@@ -103,16 +112,19 @@
     {% set _ = units.setdefault(supervisor.unit, []).append(supervisor) %}
   {% endfor %}
 
+  {% for unit, supervisors_in_unit in units | dictsort %}
   <div class="unit-section">
-    {% for unit, supervisors_in_unit in units.items() %}
       <h2>{{ unit }}</h2>
-      <ul>
-        {% for supervisor in supervisors_in_unit %}
-          <li><a href="#{{ supervisor.slug }}">{{ supervisor.name }}</a></li>
+      <div class="unit-grid">
+        {% for supervisor in supervisors_in_unit | sort(attribute='name') %}
+          <a href="#{{ supervisor.slug }}">
+            <img src="file://{{ supervisor.photo_pdf_path }}" alt="{{ supervisor.name }}">
+            <span>{{ supervisor.name }}</span>
+          </a>
         {% endfor %}
-      </ul>
-    {% endfor %}
+      </div>
   </div>
+  {% endfor %}
 
   {% for supervisor in supervisors %}
     <div class="supervisor" id="{{ supervisor.slug }}">


### PR DESCRIPTION
## Summary
- Show supervisor photos and names in a responsive grid on the index page
- Generate a similar topic-grouped photo grid in the PDF
- Sort supervisors by unit and name for consistent ordering

## Testing
- ⚠️ `python src/build.py` *(missing `yaml`; dependency installation failed due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_68bd848c0b74832989f7a3a75cb11c62